### PR TITLE
change countries getter names to getCountry{X}By{Y}

### DIFF
--- a/external/geonames/update_countries.py
+++ b/external/geonames/update_countries.py
@@ -51,6 +51,6 @@ for attr in _attrs:
     for other in others:
         print
         print
-        print '''def get{other[0]}By{attr[0]}({attr[1]}):
+        print '''def getCountry{other[0]}By{attr[0]}({attr[1]}):
     """Get country {other[0]} by {attr[0]}"""
     return {lookup}[{attr[1]}].{other[1]}'''.format(other=other, attr=attr, lookup=lookup)

--- a/geodis/countries.py
+++ b/geodis/countries.py
@@ -259,17 +259,17 @@ countries = [
 countriesById = {c.id: c for c in countries}
 
 
-def get2LetterCodeById(id):
+def getCountry2LetterCodeById(id):
     """Get country 2LetterCode by Id"""
     return countriesById[id].ISO
 
 
-def get3LetterCodeById(id):
+def getCountry3LetterCodeById(id):
     """Get country 3LetterCode by Id"""
     return countriesById[id].ISO3
 
 
-def getNameById(id):
+def getCountryNameById(id):
     """Get country Name by Id"""
     return countriesById[id].name
 
@@ -277,17 +277,17 @@ def getNameById(id):
 countriesByName = {c.name: c for c in countries}
 
 
-def get2LetterCodeByName(name):
+def getCountry2LetterCodeByName(name):
     """Get country 2LetterCode by Name"""
     return countriesByName[name].ISO
 
 
-def get3LetterCodeByName(name):
+def getCountry3LetterCodeByName(name):
     """Get country 3LetterCode by Name"""
     return countriesByName[name].ISO3
 
 
-def getIdByName(name):
+def getCountryIdByName(name):
     """Get country Id by Name"""
     return countriesByName[name].id
 
@@ -295,17 +295,17 @@ def getIdByName(name):
 countriesBy2LetterCode = {c.ISO: c for c in countries}
 
 
-def get3LetterCodeBy2LetterCode(ISO):
+def getCountry3LetterCodeBy2LetterCode(ISO):
     """Get country 3LetterCode by 2LetterCode"""
     return countriesBy2LetterCode[ISO].ISO3
 
 
-def getIdBy2LetterCode(ISO):
+def getCountryIdBy2LetterCode(ISO):
     """Get country Id by 2LetterCode"""
     return countriesBy2LetterCode[ISO].id
 
 
-def getNameBy2LetterCode(ISO):
+def getCountryNameBy2LetterCode(ISO):
     """Get country Name by 2LetterCode"""
     return countriesBy2LetterCode[ISO].name
 
@@ -313,16 +313,16 @@ def getNameBy2LetterCode(ISO):
 countriesBy3LetterCode = {c.ISO3: c for c in countries}
 
 
-def get2LetterCodeBy3LetterCode(ISO3):
+def getCountry2LetterCodeBy3LetterCode(ISO3):
     """Get country 2LetterCode by 3LetterCode"""
     return countriesBy3LetterCode[ISO3].ISO
 
 
-def getIdBy3LetterCode(ISO3):
+def getCountryIdBy3LetterCode(ISO3):
     """Get country Id by 3LetterCode"""
     return countriesBy3LetterCode[ISO3].id
 
 
-def getNameBy3LetterCode(ISO3):
+def getCountryNameBy3LetterCode(ISO3):
     """Get country Name by 3LetterCode"""
     return countriesBy3LetterCode[ISO3].name

--- a/test/test_countries.py
+++ b/test/test_countries.py
@@ -8,35 +8,35 @@ class CountriesTestCase(TestCase):
             if country.ISO3 in ('SCG', 'ANT'):
                 continue
             self.assertTrue(country.id, 'Country {} has invalid id'.format(country))
-            self.assertEqual(getNameById(country.id), country.name)
-            self.assertEqual(get2LetterCodeById(country.id), country.ISO)
-            self.assertEqual(get3LetterCodeById(country.id), country.ISO3)
+            self.assertEqual(getCountryNameById(country.id), country.name)
+            self.assertEqual(getCountry2LetterCodeById(country.id), country.ISO)
+            self.assertEqual(getCountry3LetterCodeById(country.id), country.ISO3)
         ids = [country.id for country in countries]
         assert len(set(ids)) == len(ids) - 1  # SCG, ANT have id = None
 
     def testNames(self):
         for country in countries:
             self.assertTrue(country.name, 'Country {} has invalid name'.format(country))
-            self.assertEqual(getIdByName(country.name), country.id)
-            self.assertEqual(get2LetterCodeByName(country.name), country.ISO)
-            self.assertEqual(get3LetterCodeByName(country.name), country.ISO3)
+            self.assertEqual(getCountryIdByName(country.name), country.id)
+            self.assertEqual(getCountry2LetterCodeByName(country.name), country.ISO)
+            self.assertEqual(getCountry3LetterCodeByName(country.name), country.ISO3)
         names = [country.name for country in countries]
         assert len(set(names)) == len(names)
 
     def test2LetterCodes(self):
         for country in countries:
             self.assertTrue(country.ISO, 'Country {} has invalid ISO'.format(country))
-            self.assertEqual(getIdBy2LetterCode(country.ISO), country.id)
-            self.assertEqual(getNameBy2LetterCode(country.ISO), country.name)
-            self.assertEqual(get3LetterCodeBy2LetterCode(country.ISO), country.ISO3)
+            self.assertEqual(getCountryIdBy2LetterCode(country.ISO), country.id)
+            self.assertEqual(getCountryNameBy2LetterCode(country.ISO), country.name)
+            self.assertEqual(getCountry3LetterCodeBy2LetterCode(country.ISO), country.ISO3)
         ISOs = [country.ISO for country in countries]
         assert len(set(ISOs)) == len(ISOs)
 
     def test3LetterCodes(self):
         for country in countries:
             self.assertTrue(country.ISO3, 'Country {} has invalid ISO3'.format(country))
-            self.assertEqual(getIdBy3LetterCode(country.ISO3), country.id)
-            self.assertEqual(getNameBy3LetterCode(country.ISO3), country.name)
-            self.assertEqual(get2LetterCodeBy3LetterCode(country.ISO3), country.ISO)
+            self.assertEqual(getCountryIdBy3LetterCode(country.ISO3), country.id)
+            self.assertEqual(getCountryNameBy3LetterCode(country.ISO3), country.name)
+            self.assertEqual(getCountry2LetterCodeBy3LetterCode(country.ISO3), country.ISO)
         ISO3s = [country.ISO3 for country in countries]
         assert len(set(ISO3s)) == len(ISO3s)


### PR DESCRIPTION
This is nicer:

```
from geodis.countries import getCountryNameById
```

The previous version was:

```
from geodis.countries import getNameById
```
